### PR TITLE
Website feedback fixes

### DIFF
--- a/docs/characters/hydro/tartaglia.md
+++ b/docs/characters/hydro/tartaglia.md
@@ -209,7 +209,7 @@ A chart of Tartgalia's different Riptide effects
 | :---------------- | :------------------ | :---------------- | :-------------------- | :-------------------- |
 | Source            | Charge shot on mark | Melee hit on mark | Enemy death with mark | Melee Burst with mark |
 | Skill DMG \(T6%\) | 17.63% \* 3         | 86.5%             | 86.8%                 | 168%                  |
-| Particles         | --                  | 1 per proc        | --                    | --                    |
+| Particles         | 1 every 3s          | 1 every 3s        | --                    | --                    |
 | GU                | 1U                  | 1U                | 2U                    | 2U                    |
 | ICD               | Standard            | None              | None                  | None                  |
 | Snapshot          | --                  | Dynamic           | --                    | --                    |
@@ -219,6 +219,7 @@ A chart of Tartgalia's different Riptide effects
 **Notes**
 
 * **Riptide** has a 10s duration \(without Ascension 1\).
+* 1 Hydro Particle on **Riptide Flash** and **Riptide Slash** trigger both held to a 3s cooldown for all generation.
 
 </TabItem>
 

--- a/docs/combat-mechanics/_formulas/amplifying.md
+++ b/docs/combat-mechanics/_formulas/amplifying.md
@@ -5,6 +5,5 @@ $$
 $$
 \text{ReactionMultiplier} = \begin{cases}
   2 & \text{if, triggering Vaporize with {\color{4688ff}Hydro} or Melt with {\color{f68f9a}Pyro}}\\
-  1.5 & \text{if, triggering Vaporize with {\color{f68f9a}Pyro} or Melt with {\color{7ba4d3}Cryo}}\\
-  1 & \text{otherwise} \end{cases}
+  1.5 & \text{if, triggering Vaporize with {\color{f68f9a}Pyro} or Melt with {\color{7ba4d3}Cryo}}\end{cases}
 $$

--- a/docs/evidence/characters/hydro/tartaglia.md
+++ b/docs/evidence/characters/hydro/tartaglia.md
@@ -159,6 +159,28 @@ Swapping off of Childe as soon as possible will minimize his cooldown if you mad
 
 ## Riptide Mechanics
 
+### Correcting Childe Energy Generation
+
+**By:** Mystathi\#9705  
+**Added:** <Version date="2023-03-24" />  
+**Last tested:** <VersionHl date="2023-03-24" />  
+[Discussion](https://tickets.deeznuts.moe/transcripts/correcting-childe-energy-generation)
+
+**Finding:**  
+The TCL's information on Childe's energy generation was wrong. The following information is not really a finding because it's been known for ages.  
+  
+Childe's Particle Generation is:  
+- A Hydro Particle on Riptide Flash trigger  
+- A Hydro Particle on Riptide Slash trigger  
+- Held to a 3s ICD for all generation  
+  
+**Evidence:**  
+[YouTube](https://youtu.be/4xfdaguT3kg)  
+[YouTube](https://youtu.be/9TtN_npBwno)  
+  
+**Significance:**  
+Correcting misinformation. Knowing Childe generates particles in Ranged Stance is also important.
+
 ### Riptide Burst \(Enemy Kill\) can be triggered by other units
 
 **By:** Cola\#4314


### PR DESCRIPTION
* **Fixed Amp reaction section of dmg formula** to not include a 1x reaction multiplier for non amp reactions when calculating the amp multiplier. _This wrongly made non reacted/amped hits scale with em which is obviously an error_
* **Fixed Tartaglia's Riptide energy gen** w/ respect to #correcting-childe-energy-generation also added ticket to vault bcdocumentation 