### PR TITLE
Update top bar to match branding

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -258,8 +258,8 @@ const config = {
             title: 'More',
             items: [
               {
-                label: 'KQM',
-                href: 'https://keqingmains.com/',
+                label: 'KQM Guides',
+                href: 'https://kqm.gg/',
               },
               {
                 label: 'Discord',


### PR DESCRIPTION
Changes KeqingMains link to say KQM Guides and link to kqm.gg for brand consistency