### PR TITLE
Removed Instructions Header

### DIFF
--- a/docs/resources/tools/portraits.md
+++ b/docs/resources/tools/portraits.md
@@ -10,10 +10,8 @@ A tool for making team portraits to use on KeqingMains guides. Based on muakasan
 Recommended to use a Chromium based browser due to [imageSmoothingQuality](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingQuality#browser_compatibility) support.
 :::
 
-## Instructions
-
 <details>
-  <summary>Show Instructions</summary>
+  <summary>Instructions</summary>
   
   + Click on an icon below to add them to the team.
   + Shift + click on an icon below to add them to the last icon as a multi-icon.


### PR DESCRIPTION
<img width="1160" height="608" alt="image" src="https://github.com/user-attachments/assets/42fdb8cb-8760-467d-b6ea-b72957b13e42" />

Just removing from the used up space at the top, if you don't like it reject